### PR TITLE
set-proofreading-reward.py Not working

### DIFF
--- a/scripts/proofreading-metadata/set-proofreading-reward.py
+++ b/scripts/proofreading-metadata/set-proofreading-reward.py
@@ -1,4 +1,4 @@
-import os
+import os 
 from math import floor
 from ruamel.yaml import YAML
 


### PR DESCRIPTION
When run, it gives back this message:     def is_original(data, language)
                                   ^
SyntaxError: expected ':'