### PR TITLE
set-proofreading-reward.py - not working

### DIFF
--- a/scripts/proofreading-metadata/set-proofreading-reward.py
+++ b/scripts/proofreading-metadata/set-proofreading-reward.py
@@ -1,5 +1,5 @@
 import os 
-from math import floor
+from math import floor 
 from ruamel.yaml import YAML
 
 BASE_FEE = 2500


### PR DESCRIPTION
When run, it gives back the following error:

    def is_original(data, language)
                                   ^
SyntaxError: expected ':'